### PR TITLE
DXC, SPIRV-Cross and glslc setup

### DIFF
--- a/gltfdemo/generate.py
+++ b/gltfdemo/generate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse, functools, io, os, pathlib, subprocess, sys
+import abc, argparse, functools, io, os, pathlib, subprocess, sys
 import multiprocessing as mp
 from typing import List, NamedTuple
 from pygltflib import GLTF2
@@ -23,21 +23,21 @@ from metashade.glsl import glslc
 
 import _impl
 
-class _Shader:
+class _Shader(abc.ABC):
     def __init__(self, file_path):
         self._file_path = file_path
 
-    @staticmethod
+    @abc.abstractclassmethod
     def _get_entry_point_name():
-        return None
+        pass
     
-    @staticmethod
+    @abc.abstractclassmethod
     def _get_hlsl_profile():
-        return None
+        pass
     
-    @staticmethod
+    @abc.abstractclassmethod
     def _get_glsl_stage():
-        return None
+        pass
 
     def compile(self, to_glsl : bool) -> str:
         log = io.StringIO()
@@ -96,7 +96,7 @@ class _PixelShader(_Shader):
         return _impl.ps_main
     
     @staticmethod
-    def _get_profile():
+    def _get_hlsl_profile():
         return 'ps_6_0'
     
     @staticmethod

--- a/metashade/glsl/__init__.py
+++ b/metashade/glsl/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Pavlo Penenko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/metashade/glsl/glslc.py
+++ b/metashade/glsl/glslc.py
@@ -1,0 +1,71 @@
+# Copyright 2022 Pavlo Penenko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib, shutil, subprocess
+from typing import NamedTuple
+from metashade.util import perf
+
+def identify():
+    print(f'Found glslc executable: {shutil.which("glslc")}')
+    
+    args = [
+        'glslc',
+        '--version'
+    ]
+    result = subprocess.run( args, capture_output = True )
+    print( result.stdout.decode() )
+
+class CompilationResult(NamedTuple):
+    returncode : int
+    out_path : pathlib.Path
+
+def compile(
+    src_path : str,
+    entry_point_name : str,
+    target_env : str,
+    shader_stage : str,
+    include_paths = None,
+    to_spirv : bool = False,
+    output_to_file : bool = False
+) -> CompilationResult:
+    args = [
+        'glslc',
+        '--target-env', target_env,
+        '-fshader-stage', shader_stage,
+        '-fentry-point', entry_point_name,
+        src_path
+    ]
+
+    if include_paths:
+        for path in include_paths:
+            args += ['-I', path]
+
+    message = 'glslc compiling'
+    if output_to_file:
+        out_path = pathlib.Path(src_path).with_suffix('.spv')
+        args += ['-o', out_path]
+        message += f' {out_path}'
+
+    with perf.TimedScope(message):
+        result = subprocess.run( args, capture_output = True )
+
+    if result.returncode != 0:
+        print( f'DXC compilation failed with code {result.returncode}, '
+            f'stderr:\n{result.stderr.decode()}'
+        )
+    
+    return CompilationResult(
+        returncode = result.returncode,
+        out_path = out_path if output_to_file else None
+    )

--- a/metashade/hlsl/dxc.py
+++ b/metashade/hlsl/dxc.py
@@ -19,10 +19,7 @@ from metashade.util import perf
 def identify():
     print(f'Found DXC executable: {shutil.which("dxc")}')
     
-    args = [
-        'dxc',
-        '--version'
-    ]
+    args = [ 'dxc', '--version' ]
     dxc_result = subprocess.run( args, capture_output = True )
     print( dxc_result.stdout.decode() )
 

--- a/metashade/hlsl/dxc.py
+++ b/metashade/hlsl/dxc.py
@@ -25,8 +25,8 @@ def identify():
 
 def compile(
     src_path : str,
-    entry_point_name : str,
     profile : str,
+    entry_point_name : str = None,  # can be None for libraries
     output_path : str = None,
     include_paths = None,
     to_spirv : bool = False
@@ -34,9 +34,11 @@ def compile(
     args = [
         'dxc',
         '-T', profile,
-        '-E', entry_point_name,
         src_path
     ]
+
+    if entry_point_name is not None:
+        args += [ '-E', entry_point_name ]
 
     if to_spirv:
         args += [
@@ -54,6 +56,6 @@ def compile(
         message += f' {output_path}'
 
     with perf.TimedScope(message):
-        result = subprocess.run( args, capture_output = True )
+        result = subprocess.run( args )
 
     result.check_returncode()

--- a/metashade/util/spirv_cross.py
+++ b/metashade/util/spirv_cross.py
@@ -20,8 +20,10 @@ _exe_name = 'spirv-cross'
 def identify():
     print(f'Found SPIRV-Cross executable: {shutil.which(_exe_name)}')
 
-def spirv_to_glsl(spirv_path : str):
-    glsl_path = pathlib.Path(spirv_path).with_suffix('.glsl')
+def spirv_to_glsl(
+    spirv_path : str,
+    glsl_path : str
+):
     args = [
         _exe_name,
         '--output', glsl_path,

--- a/tests/_base.py
+++ b/tests/_base.py
@@ -34,17 +34,17 @@ class Base:
             if hlsl_path is not None else io.StringIO()
         )
 
-    def _compile(self, hlsl_path, include_path = None, as_lib : bool = False):
+    def _compile(self, hlsl_path, as_lib : bool = False):
         # LIB profiles support DXIL linking and therefore allow function
         # declarations without definitions.
         # Pure declarations may also be useful in other profiles if the
         # definition is found elsewhere in the compilation unit, e.g. in an
         # included header.
-        assert 0 == dxc.compile(
+        dxc.compile(
             src_path = hlsl_path,
             entry_point_name = self._entry_point_name,
             profile = 'lib_6_5' if as_lib else 'ps_6_0',
             include_paths = [
                 pathlib.Path(sys.modules[self.__module__].__file__).parent
             ]
-        ).returncode
+        )

--- a/tests/fail.hlsl
+++ b/tests/fail.hlsl
@@ -1,0 +1,4 @@
+float4 add(float4 a, float4 b)
+{
+	return (a + c);
+}

--- a/tests/test_dxc.py
+++ b/tests/test_dxc.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Pavlo Penenko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib, pytest, sys
+from subprocess import CalledProcessError
+from metashade.hlsl import dxc
+
+class TestDxc:
+    def test_dxc_failure(self):
+        parent_dir = pathlib.Path(sys.modules[self.__module__].__file__).parent
+        with pytest.raises(CalledProcessError):
+            dxc.compile(
+                src_path = parent_dir / 'fail.hlsl',
+                profile = 'lib_6_5',
+            )


### PR DESCRIPTION
1. First version of calling `glslc`
2. All of the tools raise an exception on failure instead of returning error codes.
3. Output paths are formed by external code and passed to the tools to simplify dependencies in tool chains.
4. DXC's standard output is not captured, synchronizing it is the responsibility of the external parallel jobs.